### PR TITLE
changing UTF symbol for mouse

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,8 +61,8 @@ markdown_extensions:
                 'page-up': '⇞ Page Up',
                 'tab': 'Tab ⇥',
                 'enter': 'Enter ⏎',
-                'left-button': '→🖰 Left Click',
-                'right-button': '🖰← Right Click'
+                'left-button': '→🖯 Left Click',
+                'right-button': '🖯← Right Click'
             }
 
 extra_css:


### PR DESCRIPTION
@FloChiff could you tell me if you still have the same problem as mentioned in #79 with this new symbol?

There aren't many UTF characters for representing a mouse so if it doesn't work, we'll have to think of something else to represent the action of clicking on the left or right button.